### PR TITLE
Refresh launch status docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,12 @@ Review prompts and external review support material.
 
 - `claude-second-opinion-prompt.md`
 
+### `docs/archive/`
+
+Archived historical snapshots and retired variants kept for reference.
+
+- `homepage/`
+
 ## Source Of Truth Guidance
 
 - Quick re-entry: `docs/getting-oriented.md`

--- a/docs/agile/project-status.md
+++ b/docs/agile/project-status.md
@@ -4,7 +4,8 @@
 
 - Date: April 5, 2026
 - Stage: Stage 1 / accelerated launch prep
-- Delivery state: structurally strong first build, approved custom-site direction, compressed launch schedule targeting April 14, 2026
+- Delivery state: strong static-site foundation with active design and content refinement, but the workspace is currently carrying a homepage source-of-truth mismatch that should be resolved before more homepage work continues
+- GitHub tracking state: repository exists on GitHub as `emjhayzi/recovery-and-grief-ma-org`, but no open issues or pull requests were visible during this status refresh
 
 ## Current Build Summary
 
@@ -14,111 +15,117 @@ The project is a static multi-page website with:
 - 1 shared stylesheet (~2,240 lines)
 - 1 shared JavaScript file
 - 15 image assets (13 hero/card images + 2 partner logos)
-- local preview scripts for simple browser testing
-- supporting docs for launch, hosting, and review
+- local preview scripts for browser testing
+- supporting Agile, product, and operations documentation
 - Cloudflare Pages staging pipeline with GitHub Actions fallback
+
+## Current Workspace Signal
+
+The local workspace now shows a mix of planned work, active refinements, and one important recovery item:
+
+- `publish/index.html` contains the newer "You Are Not Alone" homepage variant with the six pathway cards integrated into the hero stage
+- root `index.html` was accidentally blanked locally on April 5, 2026 and then restored from git `HEAD` so work could continue safely
+- because of that recovery step, the root homepage source and the `publish/` homepage are currently out of sync and need reconciliation
+- inner pages have strong structure, but launch-readiness gaps remain visible in team placeholders, volunteer-page intent, whole-person content completion, and direct-action pathways
+- typography and visual atmosphere have been pushed forward significantly in the current pass, but CTA clarity and public-facing completeness still need attention
 
 ## Recent Design And Content Updates
 
-The current pass focused on page implementation from the v3-0 copy deck series and visual system refinement:
+The most meaningful recent work reflected in the docs and workspace is:
 
-- the About Us page was split into Who We Are (`who-we-are.html`) and What We Do (`what-we-do.html`), accessible through a navigation dropdown
-- the Direct Connections page (`connect.html`) was rebuilt from the v3-0 copy deck with alternating image/text bands, a prominent email CTA to `connect@recoveryandgrief-MA.org`, program teaser blocks (Get Help Soon / Get Ongoing Help), and lower explanatory content
-- per-page atmospheric hero backgrounds use real Unsplash photography with CSS gradient fade overlays
-- the header was restructured as a three-column CSS grid with SADOD and TSWR logos flanking centered brand content
-- navigation was redesigned to pipe-separated links on a single nowrap row
-- the SADOD logo was pixel-edited to recolor inscription text and clean compression artifacts
-- page transition animations, staggered IntersectionObserver reveals, and button shimmer effects are in place
-- the homepage hero was reworked as six pathway cards integrated directly into the hero stage
+- the About Us section was split into Who We Are (`who-we-are.html`) and What We Do (`what-we-do.html`) under a navigation dropdown
+- `connect.html` was rebuilt around a clearer direct-support story and the primary email route `connect@recoveryandgrief-MA.org`
+- per-page atmospheric hero backgrounds now use real photography with gradient fade overlays
+- the shared header/footer system now presents the SADOD and TSWR brands as a co-branded program rather than a generic site shell
+- the homepage design direction evolved toward a stronger pathway-led experience, with card imagery and a simplified primary message
+- page transitions, reveal effects, and general front-end cleanup improved the perceived polish of the site
 
-## Recent Engineering Cleanup
+## Recent Engineering And Process Updates
 
-The latest engineering pass focused on maintainability and repeatable review:
-
-- removed dead CSS branches from older homepage-hero experiments that were no longer used by the live markup
-- simplified page-to-page transition logic to reduce flicker while preserving a softer internal fade
-- added an internal design-lab page and helper launcher for controlled visual tuning during staging review
-- refreshed the Cloudflare publish helper so staging exports include the current internal design tools
-- added QA documentation so future browser review can follow the same smoke-check process
+- helper scripts and the `publish/` workflow were improved so staging can be refreshed more reliably
+- a design-lab page was added to support controlled visual iteration without rewriting the live stylesheet first
+- documentation coverage is now solid across status, backlog, roadmap, runbook, QA, and launch planning
+- the repo is on GitHub and configured for Cloudflare Pages staging, but GitHub issue/project tracking has not yet been populated
 
 ## Current Site Map
 
-- `index.html`: homepage and primary pathway selection
-- `about.html`: legacy about page (retained for routing)
-- `who-we-are.html`: who we are — team, mission, peer grief support model
-- `what-we-do.html`: what we do — programs, RIVER model, support options
-- `connect.html`: direct connection with alternating image/text layout and email CTA
-- `groups.html`: support group overview and joining guidance
-- `whole-person.html`: whole-person recovery support framing
-- `resources.html`: curated resource path
+- `index.html`: homepage and primary entry point
+- `about.html`: legacy about page retained for routing
+- `who-we-are.html`: mission, peer grief support framing, and team placeholder area
+- `what-we-do.html`: programs, RIVER model, and support options
+- `connect.html`: direct connection and one-on-one support framing
+- `groups.html`: group support overview and joining guidance
+- `whole-person.html`: broader recovery-path framing and video content
+- `resources.html`: curated recovery/resource path
 - `help-others.html`: future volunteer pathway
 
 ## What Is Working Well
 
-- Clear multi-page information architecture with About Us dropdown split
-- Consistent design language with per-page hero atmospheres
-- Direct Connections page rebuilt from approved copy deck with clear contact pathway
-- Page-to-page transitions and staggered section reveal animations
-- Basic accessibility support such as skip link and menu toggle semantics
-- Shared front-end files make the site easy to maintain
+- Clear multi-page information architecture with an About Us split that makes the site easier to scan
+- Stronger-than-average visual direction for a static nonprofit-style site
+- Consistent shared CSS/JS architecture that keeps maintenance simple
+- Direct support, group support, recovery pathway, and resources each have their own page instead of being collapsed into one long landing page
+- Basic accessibility support such as skip link, menu semantics, focus styles, and reduced-motion handling
 - Strong documentation foundation across Agile, product, and operations
-- Cloudflare Pages staging pipeline with automated publish bundle
+- Cloudflare Pages staging path is documented and technically viable
 
 ## What Is Not Finished Yet
 
-- Final team bios, photos, and trust-building details
-- Final group schedule or sign-up flow
-- Approved external resources and partner links
-- Request Help form destination (linked from connect.html)
-- Video embeds for whole-person page
-- Some placeholder copy in teaser sections pending client approval
-- Final static host selection and deployment workflow
-- Mobile view audit and responsive refinements
-- Final production launch verification
+- Canonical homepage source is not settled between root `index.html` and `publish/index.html`
+- Final team bios, partner details, and trust-building content are still missing
+- Final group schedule, sign-up flow, or directory handoff is still missing
+- High-intent CTA paths are still too passive in several places and need clearer clickable next steps
+- Whole-person page still has partial/placeholder content
+- `help-others.html` still needs a product decision before launch
+- Final approved external resources and outbound links are still incomplete
+- Mobile audit, accessibility pass on final content, and launch QA are still pending
+- Final static host, DNS, and production deployment workflow are not yet locked
 
 ## Current Completion View
 
 ### Completed Or Mostly Complete
 
-- site structure (9 public pages)
-- visual system with per-page hero atmospheres
-- responsive navigation with About Us dropdown
-- Direct Connections page rebuilt from copy deck
-- page-level SEO titles and descriptions
-- page transitions and reveal animations
-- local testing workflow
-- Cloudflare Pages staging pipeline
-- project management documentation baseline
+- site structure (9 public pages plus design lab)
+- shared visual system and page-specific hero treatment
+- navigation redesign including About Us dropdown
+- connect page rebuild around the primary email route
+- page-level SEO title/description coverage
+- transition and reveal interactions
+- local preview and publish workflow docs
+- baseline Agile and operations documentation
 
 ### Partially Complete
 
-- content polish
+- homepage refinement
 - trust signals
-- calls to action
+- CTA clarity and contact flow
+- resource curation
 - footer completeness
-- operational handoff
+- GitHub delivery tracking
 
 ### Not Yet Complete
 
 - production deployment
-- live form/contact flow
-- analytics/search-console setup
-- final external link review
+- live form/contact workflow beyond email
+- full launch QA pass
+- analytics/search-console decision
+- final external-link review
 
 ## Recently Resolved Decisions
 
-- The client approved the custom static-site direction rather than keeping the full website build inside Squarespace
-- Ongoing website care will be handled directly by the website designer-developer
-- The About Us section was split into Who We Are and What We Do with a dropdown
-- The Direct Connections page layout was implemented as alternating image/text bands from the v3-0 copy deck
-- The primary contact email is `connect@recoveryandgrief-MA.org`
-- Site typography was switched to Geneva per client direction
+- the client approved the custom static-site direction rather than a full Squarespace build
+- ongoing care is expected to be handled directly by the website designer-developer
+- the About Us section was split into Who We Are and What We Do
+- the primary direct-contact email is `connect@recoveryandgrief-MA.org`
+- site typography was switched to Geneva per client direction
 
 ## Open Decisions
 
-- Which direct contact channel is primary: phone, text, form, scheduler, or hybrid
+- Which direct contact channel is primary beyond the current email route: phone, text, form, scheduler, or hybrid
+- Which homepage variant becomes the canonical source going forward: restored root `index.html` or the newer `publish/index.html` version
 - Whether `help-others.html` stays public before a real volunteer workflow exists
-- Which static host will be used for the approved custom site
+- Which static host and DNS path will be used for production
+- Whether launch tracking should stay doc-based or move into a populated GitHub Project / issue workflow immediately
 
 ## Accelerated Launch Dates
 
@@ -127,13 +134,14 @@ The latest engineering pass focused on maintainability and repeatable review:
 - Stage 3 target: April 12, 2026
 - Production launch target: April 14, 2026
 
-## Recommended Next Sprint Focus
+## Recommended Next 48 Hours
 
-1. Finalize direct contact workflow and exact CTA language
-2. Finalize group participation instructions and exact pathway messaging
-3. Replace placeholders with approved bios, logos, and resources on the compressed timeline
-4. Confirm final hosting, DNS, and publish-readiness decisions before Stage 3
+1. Reconcile root `index.html` and `publish/index.html` so homepage work has one clear source of truth
+2. Lock the direct contact workflow and make the primary CTA path explicit across homepage, connect, groups, and footer
+3. Replace or hide the highest-visibility placeholders, especially team and volunteer-path content
+4. Finalize group-participation instructions and the resource handoff path
+5. Put launch tracking somewhere operational on GitHub, even if that starts as a docs-only PR and a first issue set
 
 ## PM Note
 
-This project is still in a healthy place structurally, but the timeline is now materially tighter. The main risk is no longer lack of structure. The main risk is compressed approval and publishing time between April 5 and April 14, 2026.
+This project is still structurally healthy. The main risk is now coordination drift: compressed approvals, unresolved public placeholders, and the temporary mismatch between the recovered root homepage and the newer publish homepage variant. The codebase is not the limiting factor; clarity of source, approvals, and launch operations is.

--- a/docs/agile/project-status.md
+++ b/docs/agile/project-status.md
@@ -4,7 +4,7 @@
 
 - Date: April 5, 2026
 - Stage: Stage 1 / accelerated launch prep
-- Delivery state: strong static-site foundation with active design and content refinement, but the workspace is currently carrying a homepage source-of-truth mismatch that should be resolved before more homepage work continues
+- Delivery state: strong static-site foundation with active design and content refinement, with the homepage now aligned on the newer "You Are Not Alone" direction
 - GitHub tracking state: repository exists on GitHub as `emjhayzi/recovery-and-grief-ma-org`, but no open issues or pull requests were visible during this status refresh
 
 ## Current Build Summary
@@ -21,11 +21,9 @@ The project is a static multi-page website with:
 
 ## Current Workspace Signal
 
-The local workspace now shows a mix of planned work, active refinements, and one important recovery item:
+The local workspace now shows a mix of planned work and active refinements:
 
-- `publish/index.html` contains the newer "You Are Not Alone" homepage variant with the six pathway cards integrated into the hero stage
-- root `index.html` was accidentally blanked locally on April 5, 2026 and then restored from git `HEAD` so work could continue safely
-- because of that recovery step, the root homepage source and the `publish/` homepage are currently out of sync and need reconciliation
+- root `index.html` and `publish/index.html` are currently aligned to the newer "You Are Not Alone" homepage variant
 - inner pages have strong structure, but launch-readiness gaps remain visible in team placeholders, volunteer-page intent, whole-person content completion, and direct-action pathways
 - typography and visual atmosphere have been pushed forward significantly in the current pass, but CTA clarity and public-facing completeness still need attention
 
@@ -45,6 +43,7 @@ The most meaningful recent work reflected in the docs and workspace is:
 - helper scripts and the `publish/` workflow were improved so staging can be refreshed more reliably
 - a design-lab page was added to support controlled visual iteration without rewriting the live stylesheet first
 - documentation coverage is now solid across status, backlog, roadmap, runbook, QA, and launch planning
+- the homepage source and publish copy are now back in alignment on the "You Are Not Alone" version
 - the repo is on GitHub and configured for Cloudflare Pages staging, but GitHub issue/project tracking has not yet been populated
 
 ## Current Site Map
@@ -71,7 +70,6 @@ The most meaningful recent work reflected in the docs and workspace is:
 
 ## What Is Not Finished Yet
 
-- Canonical homepage source is not settled between root `index.html` and `publish/index.html`
 - Final team bios, partner details, and trust-building content are still missing
 - Final group schedule, sign-up flow, or directory handoff is still missing
 - High-intent CTA paths are still too passive in several places and need clearer clickable next steps
@@ -122,7 +120,6 @@ The most meaningful recent work reflected in the docs and workspace is:
 ## Open Decisions
 
 - Which direct contact channel is primary beyond the current email route: phone, text, form, scheduler, or hybrid
-- Which homepage variant becomes the canonical source going forward: restored root `index.html` or the newer `publish/index.html` version
 - Whether `help-others.html` stays public before a real volunteer workflow exists
 - Which static host and DNS path will be used for production
 - Whether launch tracking should stay doc-based or move into a populated GitHub Project / issue workflow immediately
@@ -136,12 +133,12 @@ The most meaningful recent work reflected in the docs and workspace is:
 
 ## Recommended Next 48 Hours
 
-1. Reconcile root `index.html` and `publish/index.html` so homepage work has one clear source of truth
-2. Lock the direct contact workflow and make the primary CTA path explicit across homepage, connect, groups, and footer
-3. Replace or hide the highest-visibility placeholders, especially team and volunteer-path content
-4. Finalize group-participation instructions and the resource handoff path
-5. Put launch tracking somewhere operational on GitHub, even if that starts as a docs-only PR and a first issue set
+1. Lock the direct contact workflow and make the primary CTA path explicit across homepage, connect, groups, and footer
+2. Replace or hide the highest-visibility placeholders, especially team and volunteer-path content
+3. Finalize group-participation instructions and the resource handoff path
+4. Put launch tracking somewhere operational on GitHub, even if that starts as a docs-only PR and a first issue set
+5. Run a focused mobile and accessibility pass on the now-aligned homepage and primary support pages
 
 ## PM Note
 
-This project is still structurally healthy. The main risk is now coordination drift: compressed approvals, unresolved public placeholders, and the temporary mismatch between the recovered root homepage and the newer publish homepage variant. The codebase is not the limiting factor; clarity of source, approvals, and launch operations is.
+This project is still structurally healthy. The main risk is now coordination drift: compressed approvals, unresolved public placeholders, and launch operations that still depend on a few final product decisions. The codebase is not the limiting factor; clarity of contact flow, approvals, and launch execution is.

--- a/docs/agile/raid-log.md
+++ b/docs/agile/raid-log.md
@@ -9,7 +9,6 @@
 | R3 | Final static host provider stays unresolved | Launch timing may slip late in the process | Decide host and DNS model during launch-readiness sprint |
 | R4 | Sensitive audience may be affected by unclear language | Confusing or clinical wording could reduce engagement | Run final tone review with stakeholder approval |
 | R5 | Git workflow remains lightweight and single-maintainer | Publish history or rollback discipline may be weaker than ideal if updates are rushed | Keep regular commits and follow the publish checklist before launch changes |
-| R6 | Root source files and `publish/` bundle may drift apart | QA or staging review may happen against the wrong homepage/content variant | Reconcile source of truth before the next homepage pass and refresh `publish/` from the approved root files |
 
 ## Assumptions
 
@@ -29,7 +28,6 @@
 | I3 | Group schedule or registration path is missing | Group page lacks decisive next step | Program lead |
 | I4 | Resource links are not finalized | Resource page is still partial | Content lead |
 | I5 | Volunteer page intent is unresolved | Navigation may promise more than exists today | Product owner |
-| I6 | Homepage source-of-truth is currently split between recovered root `index.html` and newer `publish/index.html` | Team members may review or edit different homepage versions by accident | Website maintainer |
 
 ## Dependencies
 

--- a/docs/agile/raid-log.md
+++ b/docs/agile/raid-log.md
@@ -9,6 +9,7 @@
 | R3 | Final static host provider stays unresolved | Launch timing may slip late in the process | Decide host and DNS model during launch-readiness sprint |
 | R4 | Sensitive audience may be affected by unclear language | Confusing or clinical wording could reduce engagement | Run final tone review with stakeholder approval |
 | R5 | Git workflow remains lightweight and single-maintainer | Publish history or rollback discipline may be weaker than ideal if updates are rushed | Keep regular commits and follow the publish checklist before launch changes |
+| R6 | Root source files and `publish/` bundle may drift apart | QA or staging review may happen against the wrong homepage/content variant | Reconcile source of truth before the next homepage pass and refresh `publish/` from the approved root files |
 
 ## Assumptions
 
@@ -28,6 +29,7 @@
 | I3 | Group schedule or registration path is missing | Group page lacks decisive next step | Program lead |
 | I4 | Resource links are not finalized | Resource page is still partial | Content lead |
 | I5 | Volunteer page intent is unresolved | Navigation may promise more than exists today | Product owner |
+| I6 | Homepage source-of-truth is currently split between recovered root `index.html` and newer `publish/index.html` | Team members may review or edit different homepage versions by accident | Website maintainer |
 
 ## Dependencies
 

--- a/docs/archive/homepage/README.md
+++ b/docs/archive/homepage/README.md
@@ -1,0 +1,16 @@
+# Homepage Archive
+
+This folder preserves older homepage snapshots so we can reference them without digging through git history.
+
+Current active homepage source:
+
+- `/index.html`
+
+Archived snapshots added on April 5, 2026:
+
+| File | Commit | Notes |
+| --- | --- | --- |
+| `index-0317074-pre-you-are-not-alone.html` | `0317074` | Last committed homepage before the "You Are Not Alone" direction became the active version |
+| `index-c9bc7ac-initial-draft.html` | `c9bc7ac` | Initial homepage draft |
+
+These files are historical snapshots and should not be edited as live source files.

--- a/docs/archive/homepage/index-0317074-pre-you-are-not-alone.html
+++ b/docs/archive/homepage/index-0317074-pre-you-are-not-alone.html
@@ -1,0 +1,196 @@
+<!-- Archived homepage snapshot from commit 0317074: Polish mobile layout and menu accessibility -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Peer Grief Support for People in Recovery</title>
+  <meta
+    name="description"
+    content="Massachusetts peer grief support for people in recovery grieving a death from alcohol or other drugs."
+  >
+  <meta name="theme-color" content="#4f8f93">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Peer Grief Support for People in Recovery">
+  <meta
+    property="og:description"
+    content="Massachusetts peer grief support for people in recovery grieving a death from alcohol or other drugs."
+  >
+  <meta name="twitter:card" content="summary">
+  <script>
+    try {
+      if (window.sessionStorage.getItem("rgInternalPageTransition") === "1") {
+        document.documentElement.classList.add("is-page-entering");
+      }
+    } catch (error) {}
+  </script>
+  <link rel="preload" as="image" href="assets/images/sadod-logo.png" fetchpriority="high">
+  <link rel="preload" as="image" href="assets/images/tswr-logo.png" fetchpriority="high">
+  <link rel="stylesheet" href="assets/css/styles.css">
+  <script src="assets/js/script.js" defer></script>
+</head>
+<body data-page="home">
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header class="site-header">
+    <div class="brand-shell">
+      <div class="header-tri">
+        <div class="header-logo" aria-label="SADOD logo">
+          <img src="assets/images/sadod-logo.png" width="1180" height="1180" fetchpriority="high" decoding="sync" alt="SADOD - Survivors of Alcohol and Drug-related Deaths">
+        </div>
+        <div class="header-center">
+          <div class="eyebrow">Massachusetts Programs</div>
+          <a class="brand-lockup" href="index.html" aria-label="Peer Grief Support for People in Recovery home">
+            <span class="brand-title">Recovery and Grief</span>
+            <span class="brand-subtitle">Peer support for people in recovery grieving a death from alcohol or other drugs</span>
+          </a>
+          <div class="partner-line">
+            <span>In partnership with SADOD and The Sun Will Rise</span>
+          </div>
+          <button
+            class="menu-toggle"
+            type="button"
+            aria-expanded="false"
+            aria-controls="site-nav"
+            aria-label="Toggle navigation menu"
+          >
+            Menu
+          </button>
+          <nav id="site-nav" class="site-nav" aria-label="Primary navigation">
+            <a href="about.html">About Us</a>
+            <a href="connect.html">Direct Connection</a>
+            <a href="groups.html">Support Groups</a>
+            <a href="whole-person.html">Your Path</a>
+            <a href="resources.html">More Resources</a>
+            <a href="help-others.html">Help Others</a>
+          </nav>
+        </div>
+        <div class="header-logo" aria-label="The Sun Will Rise Foundation logo">
+          <img src="assets/images/tswr-logo.png" width="1316" height="1200" fetchpriority="high" decoding="sync" alt="The Sun Will Rise Foundation">
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="hero hero-home home-section" data-home-section="hero">
+      <div class="hero-atmosphere"></div>
+      <div class="hero-stage">
+        <div class="hero-copy">
+          <div class="hero-copy-inner">
+            <p class="section-kicker">Massachusetts peer grief support</p>
+            <h1>
+              <span class="hero-line">You don't have to</span>
+              <span class="hero-line"><span class="hero-emphasis">GRIEVE</span> this alone.</span>
+            </h1>
+            <p class="hero-text">
+              Losing someone to alcohol or other drugs is a grief unlike any other.
+              This site connects you with people in recovery who truly understand and can walk alongside you through it.
+            </p>
+            <div class="hero-actions">
+              <a class="button button-primary" href="connect.html">Talk to Someone Now</a>
+              <a class="button button-secondary" href="about.html">How Peer Support Works</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="hero-support-band">
+          <p class="section-kicker support-kicker">What you'll find here</p>
+          <h2 class="support-title">Start where you are.</h2>
+          <div class="support-flow" aria-label="Types of support offered">
+            <div class="support-item">
+              <strong>A real person</strong>
+              <p>Peer support grounded in lived experience.</p>
+            </div>
+            <div class="support-item">
+              <strong>Your own pace</strong>
+              <p>One-on-one, groups, and whole-person support when you're ready.</p>
+            </div>
+            <div class="support-item">
+              <strong>No clinical intake</strong>
+              <p>All recovery paths welcome. Clear next steps. No waitlist.</p>
+            </div>
+          </div>
+          <p class="support-note">
+            Start with conversation, information, or simply a place that understands this loss.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <section class="portal-section home-section" data-home-section="pathways">
+      <div class="section-heading">
+        <p class="section-kicker">Choose a starting place</p>
+        <h2>Six pathways into support</h2>
+      </div>
+      <div class="portal-grid">
+        <a class="portal-card tone-sand" href="about.html">
+          <span class="portal-number">01</span>
+          <h3>Learn About Peer Grief Support</h3>
+          <p>Find out who this support is for, what peer grief support means, and how it works.</p>
+        </a>
+        <a class="portal-card tone-teal" href="connect.html">
+          <span class="portal-number">02</span>
+          <h3>Connect With a Peer Grief Helper</h3>
+          <p>Reach out for direct support, information, and guidance about your next step.</p>
+        </a>
+        <a class="portal-card tone-clay" href="groups.html">
+          <span class="portal-number">03</span>
+          <h3>Attend a Grief Support Group</h3>
+          <p>Learn what group support is like and how to join a space that feels right for you.</p>
+        </a>
+        <a class="portal-card tone-olive" href="whole-person.html">
+          <span class="portal-number">04</span>
+          <h3>Discover Whole-Person Support</h3>
+          <p>Explore recovery-centered support that connects grief care with broader wellbeing.</p>
+        </a>
+        <a class="portal-card tone-rose" href="resources.html">
+          <span class="portal-number">05</span>
+          <h3>Check Out More Resources</h3>
+          <p>Browse carefully chosen materials, programs, and next-step links.</p>
+        </a>
+        <a class="portal-card tone-muted" href="help-others.html">
+          <span class="portal-number">06</span>
+          <h3>Volunteer to Help Others</h3>
+          <p>This page is being developed for people who may want to support others later on.</p>
+        </a>
+      </div>
+    </section>
+
+    <section class="story-band home-section" data-home-section="message">
+      <div class="band-copy">
+        <p class="section-kicker">Core message</p>
+        <h2>Compassionate, peer-led, and recovery-affirming</h2>
+        <p>
+          Everything on this site is meant to be clear, direct, non-clinical, and welcoming.
+          The goal is simple: make it easier for grieving people in recovery to find support that
+          feels safe, understandable, and genuinely human.
+        </p>
+      </div>
+      <div class="band-aside">
+        <div class="note-card">
+          <h3>Designed for this community</h3>
+          <p>
+            All recovery paths are welcome. The support described here is built specifically with
+            people in recovery in mind.
+          </p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div>
+      <strong>Recovery and Grief</strong>
+      <p>Massachusetts peer grief support for people in recovery.</p>
+    </div>
+    <div>
+      <p>SADOD + The Sun Will Rise partnership</p>
+      <div class="footer-branding" aria-label="Partner organizations">
+        <img class="footer-logo" src="assets/images/sadod-logo.png" width="1180" height="1180" decoding="async" alt="SADOD logo">
+        <img class="footer-logo" src="assets/images/tswr-logo.png" width="1316" height="1200" decoding="async" alt="The Sun Will Rise Foundation logo">
+      </div>
+      <p class="footer-note">Direct contact details and final resource links can be added in the next pass.</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/archive/homepage/index-c9bc7ac-initial-draft.html
+++ b/docs/archive/homepage/index-c9bc7ac-initial-draft.html
@@ -1,0 +1,184 @@
+<!-- Archived homepage snapshot from commit c9bc7ac: Initial website draft -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Peer Grief Support for People in Recovery</title>
+  <meta
+    name="description"
+    content="Massachusetts peer grief support for people in recovery grieving a death from alcohol or other drugs."
+  >
+  <meta name="theme-color" content="#4f8f93">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Peer Grief Support for People in Recovery">
+  <meta
+    property="og:description"
+    content="Massachusetts peer grief support for people in recovery grieving a death from alcohol or other drugs."
+  >
+  <meta name="twitter:card" content="summary">
+  <link rel="stylesheet" href="assets/css/styles.css">
+  <script src="assets/js/script.js" defer></script>
+</head>
+<body data-page="home">
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header class="site-header">
+    <div class="brand-shell">
+      <div class="header-tri">
+        <div class="header-logo" aria-label="SADOD logo">
+          <img src="assets/images/sadod-logo.png" alt="SADOD &mdash; Survivors of Alcohol and Drug-related Deaths">
+        </div>
+        <div class="header-center">
+          <div class="eyebrow">Massachusetts Programs</div>
+          <a class="brand-lockup" href="index.html" aria-label="Peer Grief Support for People in Recovery home">
+            <span class="brand-title">Recovery and Grief</span>
+            <span class="brand-subtitle">Peer support for people in recovery grieving a death from alcohol or other drugs</span>
+          </a>
+          <div class="partner-line">
+            <span>In partnership with SADOD and The Sun Will Rise</span>
+          </div>
+          <button
+            class="menu-toggle"
+            type="button"
+            aria-expanded="false"
+            aria-controls="site-nav"
+            aria-label="Toggle navigation menu"
+          >
+            Menu
+          </button>
+          <nav id="site-nav" class="site-nav" aria-label="Primary navigation">
+            <a href="about.html">About Us</a>
+            <a href="connect.html">Direct Connection</a>
+            <a href="groups.html">Support Groups</a>
+            <a href="whole-person.html">Your Path</a>
+            <a href="resources.html">More Resources</a>
+            <a href="help-others.html">Help Others</a>
+          </nav>
+        </div>
+        <div class="header-logo" aria-label="The Sun Will Rise Foundation logo">
+          <img src="assets/images/tswr-logo.png" alt="The Sun Will Rise Foundation">
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="hero hero-home home-section" data-home-section="hero">
+      <div class="hero-atmosphere"></div>
+      <div class="hero-copy">
+        <div class="hero-copy-inner">
+          <p class="section-kicker">Massachusetts peer grief support</p>
+          <h1>You don't have to grieve this alone.</h1>
+          <p class="hero-text">
+            Losing someone to alcohol or other drugs is a grief unlike any other.
+            This site connects you with people in recovery who truly understand &mdash;
+            and can walk alongside you through it.
+          </p>
+          <div class="hero-actions">
+            <a class="button button-primary" href="connect.html">Talk to Someone Now</a>
+            <a class="button button-secondary" href="about.html">How Peer Support Works</a>
+          </div>
+        </div>
+      </div>
+      <div class="hero-panel">
+        <div class="floating-card home-support-card">
+          <p class="section-kicker support-kicker">What you'll find here</p>
+          <h2 class="support-title">Start where you are.</h2>
+          <div class="support-flow" aria-label="Types of support offered">
+            <div class="support-item">
+              <strong>A real person</strong>
+              <p>Peer support that feels human and grounded in lived experience.</p>
+            </div>
+            <div class="support-item">
+              <strong>Your own pace</strong>
+              <p>One-on-one connection, groups, and whole-person support when you are ready.</p>
+            </div>
+            <div class="support-item">
+              <strong>No clinical intake</strong>
+              <p>All recovery paths welcome, with clear next steps and no waitlist.</p>
+            </div>
+          </div>
+          <p class="support-note">
+            Start with conversation, information, or simply a place that understands this loss.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <section class="portal-section home-section" data-home-section="pathways">
+      <div class="section-heading">
+        <p class="section-kicker">Choose a starting place</p>
+        <h2>Six pathways into support</h2>
+      </div>
+      <div class="portal-grid">
+        <a class="portal-card tone-sand" href="about.html">
+          <span class="portal-number">01</span>
+          <h3>Learn About Peer Grief Support</h3>
+          <p>Find out who this support is for, what peer grief support means, and how it works.</p>
+        </a>
+        <a class="portal-card tone-teal" href="connect.html">
+          <span class="portal-number">02</span>
+          <h3>Connect With a Peer Grief Helper</h3>
+          <p>Reach out for direct support, information, and guidance about your next step.</p>
+        </a>
+        <a class="portal-card tone-clay" href="groups.html">
+          <span class="portal-number">03</span>
+          <h3>Attend a Grief Support Group</h3>
+          <p>Learn what group support is like and how to join a space that feels right for you.</p>
+        </a>
+        <a class="portal-card tone-olive" href="whole-person.html">
+          <span class="portal-number">04</span>
+          <h3>Discover Whole-Person Support</h3>
+          <p>Explore recovery-centered support that connects grief care with broader wellbeing.</p>
+        </a>
+        <a class="portal-card tone-rose" href="resources.html">
+          <span class="portal-number">05</span>
+          <h3>Check Out More Resources</h3>
+          <p>Browse carefully chosen materials, programs, and next-step links.</p>
+        </a>
+        <a class="portal-card tone-muted" href="help-others.html">
+          <span class="portal-number">06</span>
+          <h3>Volunteer to Help Others</h3>
+          <p>This page is being developed for people who may want to support others later on.</p>
+        </a>
+      </div>
+    </section>
+
+    <section class="story-band home-section" data-home-section="message">
+      <div class="band-copy">
+        <p class="section-kicker">Core message</p>
+        <h2>Compassionate, peer-led, and recovery-affirming</h2>
+        <p>
+          Everything on this site is meant to be clear, direct, non-clinical, and welcoming.
+          The goal is simple: make it easier for grieving people in recovery to find support that
+          feels safe, understandable, and genuinely human.
+        </p>
+      </div>
+      <div class="band-aside">
+        <div class="note-card">
+          <h3>Designed for this community</h3>
+          <p>
+            All recovery paths are welcome. The support described here is built specifically with
+            people in recovery in mind.
+          </p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div>
+      <strong>Recovery and Grief</strong>
+      <p>Massachusetts peer grief support for people in recovery.</p>
+    </div>
+    <div>
+      <p>SADOD + The Sun Will Rise partnership</p>
+      <div class="footer-branding" aria-label="Partner organizations">
+        <img class="footer-logo" src="assets/images/sadod-logo.png" alt="SADOD logo">
+        <img class="footer-logo" src="assets/images/tswr-logo.png" alt="The Sun Will Rise Foundation logo">
+      </div>
+      <p class="footer-note">Direct contact details and final resource links can be added in the next pass.</p>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- refresh the project status snapshot to match the current workspace reality
- record that the homepage source is temporarily split between root index.html and publish/index.html`n- add the source-of-truth drift risk to the RAID log

## Notes
- docs-only change
- no functional site code changes in this PR